### PR TITLE
Replace Secret with Key in methods name

### DIFF
--- a/notification-hubs-sdk-e2etestapp/src/com/microsoft/windowsazure/messaging/e2etestapp/ApplicationContext.java
+++ b/notification-hubs-sdk-e2etestapp/src/com/microsoft/windowsazure/messaging/e2etestapp/ApplicationContext.java
@@ -33,7 +33,7 @@ public class ApplicationContext {
 		String keyValue = getNotificationHubKeyValue();
 		String notificationHubName = getNotificationHubName();
 		
-		String connectionString = ConnectionString.createUsingSharedAccessSecret(URI.create(endpoint), keyName, keyValue);
+		String connectionString = ConnectionString.createUsingSharedAccessKey(URI.create(endpoint), keyName, keyValue);
 		
 		if (clearLocalStorage) {
 			clearNotificationHubStorageData();

--- a/notification-hubs-sdk-e2etestapp/src/com/microsoft/windowsazure/messaging/e2etestapp/tests/MiscTests.java
+++ b/notification-hubs-sdk-e2etestapp/src/com/microsoft/windowsazure/messaging/e2etestapp/tests/MiscTests.java
@@ -291,7 +291,7 @@ public class MiscTests extends TestGroup {
 						csParts.put(keyValue.split("=")[0], keyValue.split("=")[1]);
 					}
 
-					String cs = ConnectionString.createUsingSharedAccessSecret(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
+					String cs = ConnectionString.createUsingSharedAccessKey(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
 							"1234567890");
 
 					NotificationHub nh = new NotificationHub(notificationHub.getNotificationHubPath(), cs, ApplicationContext.getContext());
@@ -534,7 +534,7 @@ public class MiscTests extends TestGroup {
 						csParts.put(keyValue.split("=")[0], keyValue.split("=")[1]);
 					}
 
-					String cs = ConnectionString.createUsingSharedAccessSecret(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
+					String cs = ConnectionString.createUsingSharedAccessKey(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
 							"1234567890");
 
 					NotificationHub nh = new NotificationHub(notificationHub.getNotificationHubPath(), cs, ApplicationContext.getContext());
@@ -785,7 +785,7 @@ public class MiscTests extends TestGroup {
 						csParts.put(keyValue.split("=")[0], keyValue.split("=")[1]);
 					}
 
-					String cs = ConnectionString.createUsingSharedAccessSecret(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
+					String cs = ConnectionString.createUsingSharedAccessKey(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
 							"1234567890");
 
 					NotificationHub nh = new NotificationHub(notificationHub.getNotificationHubPath(), cs, ApplicationContext.getContext());
@@ -911,7 +911,7 @@ public class MiscTests extends TestGroup {
 						csParts.put(keyValue.split("=")[0], keyValue.split("=")[1]);
 					}
 
-					String cs = ConnectionString.createUsingSharedAccessSecret(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
+					String cs = ConnectionString.createUsingSharedAccessKey(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
 							"1234567890");
 
 					NotificationHub nh = new NotificationHub(notificationHub.getNotificationHubPath(), cs, ApplicationContext.getContext());
@@ -1054,7 +1054,7 @@ public class MiscTests extends TestGroup {
 						csParts.put(keyValue.split("=")[0], keyValue.split("=")[1]);
 					}
 
-					String cs = ConnectionString.createUsingSharedAccessSecret(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
+					String cs = ConnectionString.createUsingSharedAccessKey(URI.create(csParts.get("Endpoint")), csParts.get("SharedAccessKeyName"),
 							"1234567890");
 
 					NotificationHub nh = new NotificationHub(notificationHub.getNotificationHubPath(), cs, ApplicationContext.getContext());

--- a/notification-hubs-sdk-testapp-tests/src/com/microsoft/windowsazure/messaging/testapp/tests/ConnectionStringTests.java
+++ b/notification-hubs-sdk-testapp-tests/src/com/microsoft/windowsazure/messaging/testapp/tests/ConnectionStringTests.java
@@ -29,38 +29,38 @@ import android.test.InstrumentationTestCase;
 public class ConnectionStringTests extends InstrumentationTestCase {
 	
 	public void testCreateConnectionWithFullAccessString() {
-		String cs = ConnectionString.createUsingSharedAccessSecretWithFullAccess(URI.create("http://myUrl.com"), "secret123");
+		String cs = ConnectionString.createUsingSharedAccessKeyWithFullAccess(URI.create("http://myUrl.com"), "secret123");
 		
 		assertEquals("Endpoint=http://myUrl.com;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=secret123", cs);
 	}
 	
 	public void testCreateConnectionWithListenAccessString() {
-		String cs = ConnectionString.createUsingSharedAccessSecretWithListenAccess(URI.create("http://myUrl.com"), "secret123");
+		String cs = ConnectionString.createUsingSharedAccessKeyWithListenAccess(URI.create("http://myUrl.com"), "secret123");
 		
 		assertEquals("Endpoint=http://myUrl.com;SharedAccessKeyName=DefaultListenSharedAccessSignature;SharedAccessKey=secret123", cs);
 	}
 	
 	public void testCreateConnectionWithCustomAccessString() {
-		String cs = ConnectionString.createUsingSharedAccessSecret(URI.create("http://myUrl.com"), "MyKeyName", "secret123");
+		String cs = ConnectionString.createUsingSharedAccessKey(URI.create("http://myUrl.com"), "MyKeyName", "secret123");
 		
 		assertEquals("Endpoint=http://myUrl.com;SharedAccessKeyName=MyKeyName;SharedAccessKey=secret123", cs);
 	}
 	
 	public void testCreateConnectionWithInvalidValues() {
 		try {
-			ConnectionString.createUsingSharedAccessSecret(null, "keyName", "keyValue");
+			ConnectionString.createUsingSharedAccessKey(null, "keyName", "keyValue");
 			fail("invalid parameters");
 		} catch (IllegalArgumentException e) {
 		}
 		
 		try {
-			ConnectionString.createUsingSharedAccessSecret(URI.create("http://myServer.com"), null, "keyValue");
+			ConnectionString.createUsingSharedAccessKey(URI.create("http://myServer.com"), null, "keyValue");
 			fail("invalid parameters");
 		} catch (IllegalArgumentException e) {
 		}
 		
 		try {
-			ConnectionString.createUsingSharedAccessSecret(URI.create("http://myServer.com"), "keyName", null);
+			ConnectionString.createUsingSharedAccessKey(URI.create("http://myServer.com"), "keyName", null);
 			fail("invalid parameters");
 		} catch (IllegalArgumentException e) {
 		}

--- a/notification-hubs-sdk-testapp-tests/src/com/microsoft/windowsazure/messaging/testapp/tests/NotificationHubTests.java
+++ b/notification-hubs-sdk-testapp-tests/src/com/microsoft/windowsazure/messaging/testapp/tests/NotificationHubTests.java
@@ -12,7 +12,7 @@ import android.test.InstrumentationTestCase;
 public class NotificationHubTests extends InstrumentationTestCase {
 	public void testCreateNotificationHub() {
 		String nhName = "myHub";
-		String cs = ConnectionString.createUsingSharedAccessSecretWithListenAccess(URI.create("http://myUrl.com"), "secret123");
+		String cs = ConnectionString.createUsingSharedAccessKeyWithListenAccess(URI.create("http://myUrl.com"), "secret123");
 		Context context = getInstrumentation().getTargetContext();
 		NotificationHub nh = new NotificationHub(nhName, cs, context);
 
@@ -22,7 +22,7 @@ public class NotificationHubTests extends InstrumentationTestCase {
 
 	public void testCreateNotificationHubWithInvalidValues() {
 		String nhName = "myHub";
-		String cs = ConnectionString.createUsingSharedAccessSecretWithListenAccess(URI.create("http://myUrl.com"), "secret123");
+		String cs = ConnectionString.createUsingSharedAccessKeyWithListenAccess(URI.create("http://myUrl.com"), "secret123");
 		Context context = getInstrumentation().getTargetContext();
 
 		try {
@@ -56,7 +56,7 @@ public class NotificationHubTests extends InstrumentationTestCase {
 
 	public void testRegisterWithInvalidValues() {
 		String nhName = "myHub";
-		String cs = ConnectionString.createUsingSharedAccessSecretWithListenAccess(URI.create("http://myUrl.com"), "secret123");
+		String cs = ConnectionString.createUsingSharedAccessKeyWithListenAccess(URI.create("http://myUrl.com"), "secret123");
 		Context context = getInstrumentation().getTargetContext();
 		NotificationHub nh = new NotificationHub(nhName, cs, context);
 
@@ -73,7 +73,7 @@ public class NotificationHubTests extends InstrumentationTestCase {
 
 	public void testRegisterTemplateWithInvalidValues() {
 		String nhName = "myHub";
-		String cs = ConnectionString.createUsingSharedAccessSecretWithListenAccess(URI.create("http://myUrl.com"), "secret123");
+		String cs = ConnectionString.createUsingSharedAccessKeyWithListenAccess(URI.create("http://myUrl.com"), "secret123");
 		Context context = getInstrumentation().getTargetContext();
 		NotificationHub nh = new NotificationHub(nhName, cs, context);
 
@@ -109,7 +109,7 @@ public class NotificationHubTests extends InstrumentationTestCase {
 
 	public void testUnregisterTemplateWithInvalidValues() {
 		String nhName = "myHub";
-		String cs = ConnectionString.createUsingSharedAccessSecretWithListenAccess(URI.create("http://myUrl.com"), "secret123");
+		String cs = ConnectionString.createUsingSharedAccessKeyWithListenAccess(URI.create("http://myUrl.com"), "secret123");
 		Context context = getInstrumentation().getTargetContext();
 		NotificationHub nh = new NotificationHub(nhName, cs, context);
 
@@ -124,7 +124,7 @@ public class NotificationHubTests extends InstrumentationTestCase {
 
 	public void testUnregisterAllWithInvalidValues() {
 		String nhName = "myHub";
-		String cs = ConnectionString.createUsingSharedAccessSecretWithListenAccess(URI.create("http://myUrl.com"), "secret123");
+		String cs = ConnectionString.createUsingSharedAccessKeyWithListenAccess(URI.create("http://myUrl.com"), "secret123");
 		Context context = getInstrumentation().getTargetContext();
 		NotificationHub nh = new NotificationHub(nhName, cs, context);
 

--- a/notification-hubs-sdk/src/com/microsoft/windowsazure/messaging/ConnectionString.java
+++ b/notification-hubs-sdk/src/com/microsoft/windowsazure/messaging/ConnectionString.java
@@ -35,7 +35,7 @@ public class ConnectionString {
 	 * @param accessSecret	The Shared Access Secret
 	 * @return	The connection string
 	 */
-	public static String createUsingSharedAccessSecret(URI endPoint, String keyName, String accessSecret) {
+	public static String createUsingSharedAccessKey(URI endPoint, String keyName, String accessSecret) {
 		if (endPoint == null) {
 			throw new IllegalArgumentException("endPoint");
 		}
@@ -57,12 +57,12 @@ public class ConnectionString {
 	 * @param fullAccessSecret	The Shared Access Secret
 	 * @return	The connection string
 	 */
-	public static String createUsingSharedAccessSecretWithFullAccess(URI endPoint, String fullAccessSecret) {
+	public static String createUsingSharedAccessKeyWithFullAccess(URI endPoint, String fullAccessSecret) {
 		if (isNullOrWhiteSpace(fullAccessSecret)) {
 			throw new IllegalArgumentException("fullAccessSecret");
 		}
 
-		return createUsingSharedAccessSecret(endPoint, "DefaultFullSharedAccessSignature", fullAccessSecret);
+		return createUsingSharedAccessKey(endPoint, "DefaultFullSharedAccessSignature", fullAccessSecret);
 	}
 
 	/**
@@ -71,11 +71,11 @@ public class ConnectionString {
 	 * @param listenAccessSecret	the Shared Access Secret
 	 * @return The connection string
 	 */
-	public static String createUsingSharedAccessSecretWithListenAccess(URI endPoint, String listenAccessSecret) {
+	public static String createUsingSharedAccessKeyWithListenAccess(URI endPoint, String listenAccessSecret) {
 		if (isNullOrWhiteSpace(listenAccessSecret)) {
 			throw new IllegalArgumentException("listenAccessSecret");
 		}
 
-		return createUsingSharedAccessSecret(endPoint, "DefaultListenSharedAccessSignature", listenAccessSecret);
+		return createUsingSharedAccessKey(endPoint, "DefaultListenSharedAccessSignature", listenAccessSecret);
 	}
 }


### PR DESCRIPTION
For the sake of consistency we have changed the names of few helper methods:
ConnectionString.CreateUsingSharedAccessSecret is now changed to ConnectionString.CreateUsingSharedAccessKey
ConnectionString.CreateUsingSharedAccessSecretWithFullAccess is now changed to ConnectionString.CreateUsingSharedAccessKeyWithFullAccess
ConnectionString.CreateUsingSharedAccessSecretWithListenAccess is now changed to ConnectionString.CreateUsingSharedAccessKeyWithListenAccess
