### PR TITLE
Updates for iOS 9

### DIFF
--- a/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBLocalStorage.m
+++ b/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBLocalStorage.m
@@ -12,7 +12,7 @@
 
 @synthesize isRefreshNeeded, deviceToken;
 
-static const NSString* storageVersion = @"v1.0.0";
+NSString* const storageVersion = @"v1.0.0";
 
 - (SBLocalStorage*) initWithNotificationHubPath: (NSString*) notificationHubPath
 {
@@ -83,7 +83,7 @@ static const NSString* storageVersion = @"v1.0.0";
     StoredRegistrationEntry* reg = [[StoredRegistrationEntry alloc] init];
     
     reg.RegistrationName = [SBNotificationHubHelper nameOfRegistration:registration];
-    reg.registrationId = registration.registrationId;
+    reg.RegistrationId = registration.registrationId;
     reg.ETag = registration.ETag;
     
     [self->_registrations setValue:reg forKey:reg.RegistrationName];
@@ -98,7 +98,7 @@ static const NSString* storageVersion = @"v1.0.0";
     StoredRegistrationEntry* reg = [[StoredRegistrationEntry alloc] init];
     
     reg.RegistrationName = registrationName;
-    reg.registrationId = registrationId;
+    reg.RegistrationId = registrationId;
     reg.ETag = eTag;
     
     [self->_registrations setValue:reg forKey:reg.RegistrationName];

--- a/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBNotificationHubHelper.m
+++ b/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBNotificationHubHelper.m
@@ -14,13 +14,16 @@ static char decodingTable[128];
 static NSString* decodingTableLock = @"decodingTableLock";
 
 + (NSString*) urlEncode: (NSString*)urlString{
-    return (__bridge NSString*)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)urlString, NULL,CFSTR("!*'();:@&=+$,/?%#[]"),  kCFStringEncodingUTF8);
+
+    NSCharacterSet* set = [[NSCharacterSet characterSetWithCharactersInString:@"!*'();:@&=+$,/?%#[]"] invertedSet];
+    return [urlString stringByAddingPercentEncodingWithAllowedCharacters:set];
 }
 
 + (NSString*) urlDecode: (NSString*)urlString{
+    
     return [[urlString
       stringByReplacingOccurrencesOfString:@"+" withString:@" "]
-     stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+     stringByRemovingPercentEncoding];
 }
 
 + (NSString*) createHashWithData:(NSData*)data{
@@ -82,7 +85,7 @@ static NSString* decodingTableLock = @"decodingTableLock";
 		inputLength--;
 	}
 	
-	int outputLength = inputLength * 3 / 4;
+	NSInteger outputLength = inputLength * 3 / 4;
 	NSMutableData* outputData = [NSMutableData dataWithLength:outputLength];
 	uint8_t* output = outputData.mutableBytes;
     
@@ -141,20 +144,7 @@ static NSString* decodingTableLock = @"decodingTableLock";
         return @"";
     }
     
-    NSMutableString* tags;
-    
-    for (NSString *element in tagSet) {
-        if(!tags)
-        {
-            tags=[[NSMutableString alloc] initWithString:element];
-        }
-        else
-        {
-            [tags appendString:[NSString stringWithFormat:@",%@",element]];
-        }
-    }
-    
-    return tags;
+    return [[tagSet allObjects] componentsJoinedByString:@","];
 }
 
 NSString* const domain = @"WindowsAzureMessaging";

--- a/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBTokenProvider.h
+++ b/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBTokenProvider.h
@@ -1,6 +1,7 @@
 //----------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //----------------------------------------------------------------
+#import <Foundation/Foundation.h>
 
 @interface SBTokenProvider : NSObject{
 

--- a/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBURLConnection.h
+++ b/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBURLConnection.h
@@ -8,13 +8,7 @@
 typedef void (^SBURLConnectionCompletion)(NSHTTPURLResponse*,NSData*,NSError*);
 typedef SBStaticHandlerResponse* (^StaticHandleBlock)(NSURLRequest*);
 
-@interface SBURLConnection : NSObject{
-@private
-    NSURLRequest* _request;
-    NSHTTPURLResponse* _response;
-    SBURLConnectionCompletion _completion;
-    NSMutableData *_data;
-}
+@interface SBURLConnection : NSObject
 
 - (void) sendRequest: (NSURLRequest*) request completion:(void (^)(NSHTTPURLResponse*,NSData*,NSError*))completion;
 

--- a/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBURLConnection.m
+++ b/iOS/WindowsAzureMessaging/WindowsAzureMessaging/Helpers/SBURLConnection.m
@@ -16,11 +16,6 @@ StaticHandleBlock _staticHandler;
 
 - (void) sendRequest: (NSURLRequest*) request completion:(void (^)(NSHTTPURLResponse*,NSData*,NSError*))completion;
 {
-    if( self){
-        self->_request = request;
-        self->_completion = completion;
-    }
- 
     if( _staticHandler != nil)
     {
         SBStaticHandlerResponse* mockResponse = _staticHandler(request);
@@ -34,9 +29,15 @@ StaticHandleBlock _staticHandler;
             return;
         }
     }
-    
-    NSURLConnection *theConnection = [[NSURLConnection alloc] initWithRequest:request delegate:self];
-    if(!theConnection && completion)
+
+    NSURLSession* session = [NSURLSession sharedSession];
+    NSURLSessionDataTask* task = [session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable c_data, NSURLResponse * _Nullable c_response, NSError * _Nullable c_error) {
+        completion((NSHTTPURLResponse*)c_response, c_data, c_error);
+    }];
+
+    if (task)
+        [task resume];
+    else
     {
         NSString* msg = [NSString stringWithFormat:@"Initiate request failed for %@",[request description]];
         completion(nil,nil,[SBNotificationHubHelper errorWithMsg:msg code:-1]);
@@ -55,77 +56,27 @@ StaticHandleBlock _staticHandler;
             return mockResponse.Data;
         }
     }
-    
-    return [NSURLConnection sendSynchronousRequest:request returningResponse:response error:error];
-}
 
-- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
-{
-    if(!self->_completion)
-    {
-        return;
-    }
+    __block NSData* b_data = nil;
     
-    self->_response = (NSHTTPURLResponse*)response;
-    
-    NSInteger statusCode = [self->_response statusCode];
-    if( statusCode != 200 && statusCode != 201)
-    {
-        if(statusCode != 404)
-        {
-            NSLog(@"URLRequest failed:");
-            NSLog(@"URL:%@",[[self->_request URL] absoluteString]);
-            NSLog(@"Headers:%@",[self->_request allHTTPHeaderFields]);
-        }
+    dispatch_semaphore_t wait = dispatch_semaphore_create(0);
+
+    [self sendRequest:request completion:^(NSHTTPURLResponse* c_response, NSData* c_data, NSError* c_error) {
         
-        NSString* msg = [NSString stringWithFormat:@"URLRequest failed for %@ with status code: %@",[self->_request description], [NSHTTPURLResponse localizedStringForStatusCode:statusCode]];
-
-        self->_completion(self->_response,nil,[SBNotificationHubHelper errorWithMsg:msg code:statusCode]);
-        self->_completion = nil;
-        return;
-    }
+        b_data = c_data;
+        
+        if (response)
+            *response = c_response;
+        
+        if (error)
+            *error = c_error;
+        
+        dispatch_semaphore_signal(wait);
+    }];
     
-    if([[self->_request HTTPMethod] isEqualToString:@"DELETE"])
-    {
-        self->_completion(self->_response,nil,nil);
-        self->_completion =nil;
-        return;
-    }
-
-    // if it's create registration id request, we need to execute callback here. 
-    if([[self->_request HTTPMethod] isEqualToString:@"POST"] && [[self->_response URL].path rangeOfString:@"/registrationids" options:NSCaseInsensitiveSearch].location != NSNotFound)
-    {
-        self->_completion(self->_response,nil,nil);
-        self->_completion =nil;
-        return;
-    }
+    dispatch_semaphore_wait(wait, DISPATCH_TIME_FOREVER);
     
-    _data = [[NSMutableData alloc]init];
-}
-
-- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data
-{
-    [_data appendData:data];
-}
-
--(void) connectionDidFinishLoading:(NSURLConnection *)connection
-{
-    if( self->_completion)
-    {
-        self->_completion(self->_response,_data,nil);
-        self->_completion = nil;
-    }
-    _data = nil;
-
-}
-
-- (void)connection:(NSURLConnection*)connection didFailWithError:(NSError *)error
-{
-    if(self->_completion)
-    {
-        self->_completion(self->_response,nil,error);
-        self->_completion = nil;
-    }
+    return b_data;
 }
 
 @end


### PR DESCRIPTION
Corrected warnings on const strings and properties
Replaced deprecated API calls in urlEncode/urlDecode
Use APIs for generating CSV tag list instead of manually concatenating
Replaced deprecated NSURLConnection with NSURLSession in SBURLConnection