### PR TITLE
Android sample: Removing SenderId from secrets.properties

### DIFF
--- a/Android/Samples/notification-hubs-test-app/app/build.gradle
+++ b/Android/Samples/notification-hubs-test-app/app/build.gradle
@@ -15,7 +15,6 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "senderId", "\"${System.getenv('APP_SENDER_ID') ?: secretsProperties['APP_SENDER_ID']}\"")
         buildConfigField("String", "hubName", "\"${System.getenv('APP_HUB_NAME') ?: secretsProperties['APP_HUB_NAME']}\"")
         buildConfigField("String", "hubListenConnectionString", "\"${System.getenv('APP_NH_CONNECTION_STRING') ?: secretsProperties['APP_NH_CONNECTION_STRING']}\"")
 

--- a/Android/Samples/notification-hubs-test-app/app/src/main/java/com/microsoft/notification_hubs_test_app/NotificationHelper.java
+++ b/Android/Samples/notification-hubs-test-app/app/src/main/java/com/microsoft/notification_hubs_test_app/NotificationHelper.java
@@ -25,8 +25,6 @@ public class NotificationHelper {
 
             NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
             notificationManager.createNotificationChannel(channel);
-            NotificationsManager.handleNotifications(context, BuildConfig.senderId, DemoNotificationsHandler.class);
         }
     }
-
 }


### PR DESCRIPTION
The `secretId` is not needed to send notifications using FCM. 

This PR contains two changes:
1. Removes `secretId` handling from the `build.gradle` (which processes the local `secrets.properties`)
2. Removes call to `NotificationsManager.handleNotification` from the `NotificationHelper`.